### PR TITLE
[rules_avro] Handle large file lists in zipper

### DIFF
--- a/avro/avro.bzl
+++ b/avro/avro.bzl
@@ -279,7 +279,9 @@ def _gen_impl(ctx):
         "pushd {gen_dir}".format(gen_dir = gen_dir),
         # Sort the entries when zipping in order to guarantee deterministic outputs.
         # Note that we use zip instead of jar because jar does not seem to respect insert ordering.
-        "find . -print | sort |  xargs \"${{base_dir}}/{zipper}\" c \"${{base_dir}}/{output}\"".format(
+        # We also have to write to a temp file, otherwise we won't get all of the sources
+        # added. zipper only creates, it does not append.
+        "FILE_LIST=$(mktemp); find . -print | sort > \"$FILE_LIST\" && \"${{base_dir}}/{zipper}\" c \"${{base_dir}}/{output}\" \"@$FILE_LIST\"".format(
             zipper = ctx.executable._zipper.path,
             output = ctx.outputs.codegen.path,
         ),


### PR DESCRIPTION
Currently if you have a large number of files, xargs will do the right thing and invoke zipper multiple times. However, zipper doesn't seem to append to zip files if invoked multiple times. It just writes the single invocation's worth of files. So with a large list of files, the last batch of, say, 40 files, might be the only ones in your .srcjar file. Looks like zipper actually supports param files, so just write to a temporary file with the list of files to include, and pass it to zipper that way.